### PR TITLE
chore(readme): fix the tests GitHub actions badge.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,7 @@
 
 # Inspired from https://github.com/py-cov-action/python-coverage-comment-action
 
-name: Add a coverage comment to the Pull Request
+name: coverage comment
 
 on:
   workflow_run:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@
 
 # SPDX-License-Identifier: BSD-3-Clause
 
-name: Publish package to Pypi and to the current release
+name: deploy release
 
 on:
   release:

--- a/.github/workflows/doc-preview.yml
+++ b/.github/workflows/doc-preview.yml
@@ -5,7 +5,7 @@
 
 # Inspired from https://github.com/readthedocs/actions/tree/v1/preview
 
-name: Documentation preview on readthedocs for Pull Requests
+name: doc preview
 
 on:
   pull_request_target:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -3,7 +3,7 @@
 
 # SPDX-License-Identifier: BSD-3-Clause
 
-name: Check the project is up to our quality standards
+name: qa
 
 on:
   pull_request:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@
 
 # SPDX-License-Identifier: BSD-3-Clause
 
-name: Test the code, doc building, and packaging
+name: tests
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-3-Clause
 -->
 
 [![latest-docs](https://img.shields.io/badge/docs-latest-orange.svg)](https://clapper.readthedocs.io/en/latest/)
-[![tests](https://github.com/idiap/clapper/main/actions/workflows/tests.svg)](https://github.com/idiap/clapper/actions)
+[![tests](https://github.com/idiap/clapper/actions/workflows/tests.yml/badge.svg)](https://github.com/idiap/clapper/actions)
 [![coverage](https://raw.githubusercontent.com/idiap/clapper/python-coverage-comment-action-data/badge.svg)](https://htmlpreview.github.io/?https://github.com/idiap/clapper/python-coverage-comment-action-data/htmlcov/index.html)
 [![repository](https://img.shields.io/badge/github-latest-darkblue.svg)](https://github.com/idiap/clapper)
 


### PR DESCRIPTION
Fixed the readme badge for actions to use the correct badge URL.

<!-- readthedocs-preview clapper start -->
----
📚 Documentation preview 📚: https://clapper--2.org.readthedocs.build/en/2/

<!-- readthedocs-preview clapper end -->