### PR TITLE
fix(logging): make the verbosity option more eager

### DIFF
--- a/src/clapper/click.py
+++ b/src/clapper/click.py
@@ -109,6 +109,7 @@ def verbosity_option(
                 f"option as often as desired (e.g. '-vvv' for debug)."
             ),
             callback=callback,
+            is_eager=True,  # Ensure the logger is set for ResourceOptions loading
             **kwargs,
         )(f)
 

--- a/tests/data/complex.py
+++ b/tests/data/complex.py
@@ -1,3 +1,12 @@
+import logging
+
+logger = logging.getLogger("clapper_test.config_with_logs")
+
+logger.debug("Debug level message")
+logger.info("Info level message")
+logger.warning("Warning level message")
+logger.error("Error level message")
+
 cplx = dict(
     a="test",
     b=42,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -7,8 +7,9 @@ import logging
 
 import clapper.logging
 import click
+import pytest
 
-from clapper.click import verbosity_option
+from clapper.click import ConfigCommand, ResourceOption, verbosity_option
 from click.testing import CliRunner
 
 
@@ -195,3 +196,121 @@ def test_logger_click_3x_verb():
 
     assert "debug message\ninfo message\n" in lo.getvalue()
     assert hi.getvalue() == "warning message\nerror message\n"
+
+
+# Testing the logger is also set correctly during the loading of config files.
+
+
+@pytest.fixture
+def cli_config():
+    messages = io.StringIO()
+    logger = clapper.logging.setup(
+        "clapper_test",
+        format="[%(levelname)s] %(message)s",
+        low_level_stream=messages,
+        high_level_stream=messages,
+    )
+    logger.setLevel("ERROR")  # Enforce a default level
+
+    @click.command(entry_point_group="clapper.test.config", cls=ConfigCommand)
+    @click.option("--cmp", entry_point_group="clapper.test.config", cls=ResourceOption)
+    @verbosity_option(logger, expose_value=False)
+    def cli(**_):
+        """This is the documentation provided by the user."""
+        pass
+
+    return (cli, messages)
+
+
+# Loading configs using ResourceOption
+
+
+def test_logger_click_option_config_q(cli_config):
+    cli, log_output = cli_config
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--cmp", "complex-var"])
+    expected = "[ERROR] Error level message\n"
+    assert result.exit_code == 0, result.output
+    assert log_output.getvalue() == expected
+
+
+def test_logger_click_option_config_v(cli_config):
+    cli, log_output = cli_config
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--cmp", "complex-var", "-v"])
+    expected = "[WARNING] Warning level message\n" "[ERROR] Error level message\n"
+    assert result.exit_code == 0, result.output
+    assert log_output.getvalue() == expected
+
+
+def test_logger_click_option_config_vv(cli_config):
+    cli, log_output = cli_config
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--cmp", "complex-var", "-vv"])
+    expected = (
+        "[INFO] Info level message\n"
+        "[WARNING] Warning level message\n"
+        "[ERROR] Error level message\n"
+    )
+    assert result.exit_code == 0, result.output
+    assert log_output.getvalue() == expected
+
+
+def test_logger_click_option_config_vvv(cli_config):
+    cli, log_output = cli_config
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--cmp", "complex-var", "-vvv"])
+    expected = (
+        "[DEBUG] Debug level message\n"
+        "[INFO] Info level message\n"
+        "[WARNING] Warning level message\n"
+        "[ERROR] Error level message\n"
+    )
+    assert result.exit_code == 0, result.output
+    assert log_output.getvalue().endswith(expected)
+
+
+# Loading configs using ConfigCommand
+def test_logger_click_command_config_q(cli_config):
+    cli, log_output = cli_config
+    runner = CliRunner()
+    result = runner.invoke(cli, ["complex"])
+    expected = "[ERROR] Error level message\n"
+    assert result.exit_code == 0, result.output
+    assert log_output.getvalue() == expected
+
+
+def test_logger_click_command_config_v(cli_config):
+    cli, log_output = cli_config
+    runner = CliRunner()
+    result = runner.invoke(cli, ["complex", "-v"])
+    expected = "[WARNING] Warning level message\n" "[ERROR] Error level message\n"
+    assert result.exit_code == 0, result.output
+    assert log_output.getvalue() == expected
+
+
+def test_logger_click_command_config_vv(cli_config):
+    cli, log_output = cli_config
+    runner = CliRunner()
+    result = runner.invoke(cli, ["complex", "-vv"])
+    expected = (
+        "[INFO] Info level message\n"
+        "[WARNING] Warning level message\n"
+        "[ERROR] Error level message\n"
+    )
+    assert result.exit_code == 0, result.output
+    assert log_output.getvalue() == expected
+
+
+def test_logger_click_command_config_vvv(cli_config):
+    cli, log_output = cli_config
+    runner = CliRunner()
+    result = runner.invoke(cli, ["complex", "-vvv"])
+    expected = (
+        "[DEBUG] Debug level message\n"
+        "[INFO] Info level message\n"
+        "[WARNING] Warning level message\n"
+        "[ERROR] Error level message\n"
+    )
+    assert result.exit_code == 0, result.output
+    assert log_output.getvalue().endswith(expected)


### PR DESCRIPTION
Ensure the verbosity option is handled before the configs are loaded so the logger level is set to the user's value in the config code.

Fixes #5.