### PR TITLE
CI: fix the coverage reports not being retrieved correctly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,10 @@ jobs:
       - name: Store coverage report
         uses: actions/upload-artifact@v4
         with:
-          # File renamed for thix matrix element
+          # File renamed for this matrix element
           name: coverage-${{ matrix.pixi_environment }}-${{ matrix.os }}
           path: .coverage.${{ matrix.pixi_environment }}-${{ matrix.os }}
+          if-no-files-found: error
 
   merge-coverage:
     name: Merge the coverage reports from multiple coverages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
           # File renamed for this matrix element
           name: coverage-${{ matrix.pixi_environment }}-${{ matrix.os }}
           path: .coverage.${{ matrix.pixi_environment }}-${{ matrix.os }}
+          include-hidden-files: true
           if-no-files-found: error
 
   merge-coverage:


### PR DESCRIPTION
- Include hidden files when creating artifacts from coverage reports (merging coverage reports with other names is not supported).
- Trigger an error early when no coverage report is found instead of failing when trying to load a missing file.

[related issue on coverage-comment-action](https://github.com/py-cov-action/python-coverage-comment-action/issues/473).

Fixes #7.

<!-- readthedocs-preview clapper start -->
----
📚 Documentation preview 📚: https://clapper--9.org.readthedocs.build/en/9/

<!-- readthedocs-preview clapper end -->