### PR TITLE
fix(click): minor regression fix to support complex python objects

### DIFF
--- a/src/clapper/click.py
+++ b/src/clapper/click.py
@@ -377,7 +377,7 @@ class ResourceOption(click.Option):
             (type is None)
             and (kwargs.get("default") is None)
             and (count is False)
-            and (is_flag is UNSET)
+            and (is_flag is None)
         ):
             type = CustomParamType()  # noqa: A001
 


### PR DESCRIPTION
Fixes issues observed when passing complex types as click options. 

<!-- readthedocs-preview clapper start -->
----
📚 Documentation preview 📚: https://clapper--25.org.readthedocs.build/en/25/

<!-- readthedocs-preview clapper end -->